### PR TITLE
docker: update repo name

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,4 +31,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: uolstudentlife/uol-student-life:latest
+          tags: uolstudentlife/student-life:latest


### PR DESCRIPTION
To address https://github.com/uol-student-life/student-life/pull/23#issuecomment-1618879402

The namespace is the same as the Docker Hub username. But the user name does not have special characters like hyphen (-). So we cannot name like this:

`uol-student-life/student-life`