### PR TITLE
db(content)!: replace `content` with `html` and `lexical`

### DIFF
--- a/api.http
+++ b/api.http
@@ -5,7 +5,8 @@
 
 # @name createJournal
 # @prompt journalDate date of journal in YYYY-MM-DD format
-# @prompt content content of journal entry
+# @prompt html html content of journal entry
+# @prompt lexical lexical state of journal entry
 POST /api/journal HTTP/1.1
 Host: {{HOST}}
 Accept: application/json, text/html
@@ -13,7 +14,8 @@ Content-Type: application/json
 
 {
     "journalDate": "{{journalDate}}",
-    "content": "{{content}}"
+    "html": "{{html}}",
+    "lexical": "{{lexical}}"
 }
 
 ### 
@@ -33,12 +35,14 @@ Host: {{HOST}}
 
 # @name updateJournal
 # @prompt id id of journal entry
-# @prompt content updated content of journal entry
+# @prompt html html content of journal entry
+# @prompt lexical lexical state of journal entry
 POST /api/journal/update?id={{id}} HTTP/1.1
 Host: {{HOST}}
 
 {
-    "content": "{{content}}"
+    "html": "{{html}}",
+    "lexical": "{{lexical}}"
 }
 
 ###

--- a/prisma/migrations/20230708194416_34_db_replace_content_with_html_and_lexical/migration.sql
+++ b/prisma/migrations/20230708194416_34_db_replace_content_with_html_and_lexical/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `content` on the `Content` table. All the data in the column will be lost.
+  - Added the required column `html` to the `Content` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `lexical` to the `Content` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `Content` DROP COLUMN `content`,
+    ADD COLUMN `html` LONGBLOB NOT NULL,
+    ADD COLUMN `lexical` LONGBLOB NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Journal {
 
 model Content {
   id      Int      @id @default(autoincrement())
-  content Bytes
+  html    Bytes
+  lexical Bytes
   journal Journal?
 }

--- a/server/api/journal/index.get.ts
+++ b/server/api/journal/index.get.ts
@@ -31,6 +31,8 @@ export default defineEventHandler(async (event) => {
 
   return {
     ...journal,
-    content: journal?.content.content.toString("utf8"),
+    content: undefined, // remove content from response
+    html: journal?.content.html.toString("utf8"),
+    lexical: journal?.content.lexical.toString("utf8"),
   };
 });

--- a/server/api/journal/index.post.ts
+++ b/server/api/journal/index.post.ts
@@ -19,7 +19,8 @@ export default defineEventHandler(async (event) => {
 
   const newContent = await prisma.content.create({
     data: {
-      content: Buffer.from(body.content, "utf8"),
+      html: Buffer.from(body.html, "utf8"),
+      lexical: Buffer.from(body.lexical, "utf8"),
     },
   });
 
@@ -43,6 +44,8 @@ export default defineEventHandler(async (event) => {
 
   return {
     ...journal,
-    content: journal?.content.content.toString("utf8"),
+    content: undefined, // remove content from response
+    html: journal?.content.html.toString("utf8"),
+    lexical: journal?.content.lexical.toString("utf8"),
   };
 });

--- a/server/api/journal/update.post.ts
+++ b/server/api/journal/update.post.ts
@@ -35,7 +35,8 @@ export default defineEventHandler(async (event) => {
   const updateContent = await prisma.content.update({
     where: { id: existingJournal.contentId },
     data: {
-      content: Buffer.from(body.content, "utf8"),
+      html: Buffer.from(body.html, "utf8"),
+      lexical: Buffer.from(body.lexical, "utf8"),
     },
   });
 
@@ -60,6 +61,8 @@ export default defineEventHandler(async (event) => {
 
   return {
     ...journal,
-    content: journal?.content.content.toString("utf8"),
+    content: undefined, // remove content from response
+    html: journal?.content.html.toString("utf8"),
+    lexical: journal?.content.lexical.toString("utf8"),
   };
 });


### PR DESCRIPTION
Resolves #34 

BREAKING CHANGE: `Content`.`content` will be dropped and be replaced with `Content`.`html` and `Content`.`lexical`

🚨 requires migration `npx prima migrate dev`. If your migration fails on your environment, try truncate the `Journal` table, followed by `Content` table.