### PR TITLE
mood(schema+api): create / update / remove mood from journal

### DIFF
--- a/api.http
+++ b/api.http
@@ -7,6 +7,7 @@
 # @prompt journalDate date of journal in YYYY-MM-DD format
 # @prompt html html content of journal entry
 # @prompt lexical lexical state of journal entry
+# @prompt mood mood of journal entry, it can be DEPRESSED, STRESS, RELAXED or MOTIVATED
 POST /api/journal HTTP/1.1
 Host: {{HOST}}
 Accept: application/json, text/html
@@ -15,7 +16,8 @@ Content-Type: application/json
 {
     "journalDate": "{{journalDate}}",
     "html": "{{html}}",
-    "lexical": "{{lexical}}"
+    "lexical": "{{lexical}}",
+    "mood": "{{mood}}"
 }
 
 ### 
@@ -37,12 +39,14 @@ Host: {{HOST}}
 # @prompt id id of journal entry
 # @prompt html html content of journal entry
 # @prompt lexical lexical state of journal entry
+# @prompt mood mood of journal entry, it can be DEPRESSED, STRESS, RELAXED or MOTIVATED
 POST /api/journal/update?id={{id}} HTTP/1.1
 Host: {{HOST}}
 
 {
     "html": "{{html}}",
-    "lexical": "{{lexical}}"
+    "lexical": "{{lexical}}",
+    "mood": "{{mood}}"
 }
 
 ###

--- a/erd.iuml
+++ b/erd.iuml
@@ -3,6 +3,7 @@
 
 entity "student-life/Journal" {
   **journalDate** : DateTime
+  **mood**, enum('DEPRESSED', 'STRESS', 'RELAXED', 'MOTIVATED')
   -- relationship --
   **contentId** : Int @fk to "student-life/content".id
   -- base entity --

--- a/prisma/migrations/20230731125254_mood_in_journal/migration.sql
+++ b/prisma/migrations/20230731125254_mood_in_journal/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Journal` ADD COLUMN `mood` ENUM('DEPRESSED', 'STRESS', 'RELAXED', 'MOTIVATED') NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,10 +19,19 @@ model Journal {
   tasks      Task[]
   milestones MilestonesOnJournals[]
 
+  mood MoodType?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([journalDate])
+}
+
+enum MoodType {
+  DEPRESSED
+  STRESS
+  RELAXED
+  MOTIVATED
 }
 
 model Content {

--- a/server/api/journal/index.get.ts
+++ b/server/api/journal/index.get.ts
@@ -26,6 +26,7 @@ export default defineEventHandler(async (event) => {
     select: {
       id: true,
       content: true,
+      mood: true,
       journalDate: true,
       createdAt: true,
       updatedAt: true,

--- a/server/api/journal/index.post.ts
+++ b/server/api/journal/index.post.ts
@@ -28,6 +28,7 @@ export default defineEventHandler(async (event) => {
     data: {
       contentId: newContent.id,
       journalDate: stripTime(body.journalDate),
+      mood: body.mood ?? null,
     },
   });
 
@@ -36,6 +37,7 @@ export default defineEventHandler(async (event) => {
     select: {
       id: true,
       content: true,
+      mood: true,
       journalDate: true,
       createdAt: true,
       updatedAt: true,

--- a/server/api/journal/update.post.ts
+++ b/server/api/journal/update.post.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../db";
+import type { Prisma } from "@prisma/client";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -40,12 +41,17 @@ export default defineEventHandler(async (event) => {
     },
   });
 
+  let updateJournalData: Prisma.JournalUpdateInput = {
+    updatedAt: new Date(),
+  };
+
+  if (body.mood !== undefined) {
+    updateJournalData.mood = body.mood;
+  }
+
   const updateJournal = await prisma.journal.update({
     where: { id: existingJournal.id },
-    data: {
-      contentId: updateContent.id,
-      updatedAt: new Date(),
-    },
+    data: updateJournalData,
   });
 
   const journal = await prisma.journal.findUnique({
@@ -53,6 +59,7 @@ export default defineEventHandler(async (event) => {
     select: {
       id: true,
       content: true,
+      mood: true,
       journalDate: true,
       createdAt: true,
       updatedAt: true,

--- a/server/api/journals/index.get.ts
+++ b/server/api/journals/index.get.ts
@@ -26,6 +26,7 @@ export default defineEventHandler(async (event) => {
       id: true,
       journalDate: true,
       content: true,
+      mood: true,
       createdAt: true,
       updatedAt: true,
     },


### PR DESCRIPTION
Resolves #80 & #78

# Usage

> Mood is part of a Journal entity. Mood is **optional** for each journal entry.

ENUM for Mood (defined as `MoodType` type)

> `DEPRESSED`, `STRESS`, `RELAXED`, `MOTIVATED`

Mood can be added during journal creation.

```http
POST /api/journal HTTP/1.1

{
    ...
    "mood": "RELAXED"
}
```

You can update the mood using the journal update api.

```http
POST /api/journal/update?id={{id}}

{
    ...
    "mood": "STRESS"
}
```

or you can pass in `null` to `mood` to erase mood

```http
POST /api/journal/update?id={{id}}

{
    ...
    "mood": null
}
```