### PR TITLE
ui(mood): added mood icons

### DIFF
--- a/components/MoodIcons/Depressed.vue
+++ b/components/MoodIcons/Depressed.vue
@@ -1,0 +1,3 @@
+<template>
+  <Icon name="emojione:disappointed-face" />
+</template>

--- a/components/MoodIcons/Motivated.vue
+++ b/components/MoodIcons/Motivated.vue
@@ -1,0 +1,3 @@
+<template>
+  <Icon name="emojione:flexed-biceps" />
+</template>

--- a/components/MoodIcons/Relaxed.vue
+++ b/components/MoodIcons/Relaxed.vue
@@ -1,0 +1,3 @@
+<template>
+  <Icon name="emojione:relieved-face" />
+</template>

--- a/components/MoodIcons/Stressed.vue
+++ b/components/MoodIcons/Stressed.vue
@@ -1,0 +1,3 @@
+<template>
+  <Icon name="emojione:confounded-face" />
+</template>

--- a/components/MoodTracker.vue
+++ b/components/MoodTracker.vue
@@ -1,3 +1,27 @@
 <template>
-  <Section title="Mood tracker"> </Section>
+  <Section title="Mood tracker">
+    <!-- Mood chart -->
+    <div class="px-6">
+      <span>Mood Chart</span>
+    </div>
+    <!-- Mood icons -->
+    <div class="flex justify-between px-6 py-4">
+      <div class="text-center">
+        <MoodIconsMotivated class="h-6 w-6" />
+        <span class="text-xs text-stone-400">Motivated</span>
+      </div>
+      <div class="text-center">
+        <MoodIconsRelaxed class="h-6 w-6" />
+        <span class="text-xs text-stone-400">Relaxed</span>
+      </div>
+      <div class="text-center">
+        <MoodIconsStressed class="h-6 w-6" />
+        <span class="text-xs text-stone-400">Stressed</span>
+      </div>
+      <div class="text-center">
+        <MoodIconsDepressed class="h-6 w-6" />
+        <span class="text-xs text-stone-400">Depressed</span>
+      </div>
+    </div>
+  </Section>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   devtools: { enabled: true },
-  modules: ["@nuxthq/ui", "@nuxtjs/color-mode"],
+  modules: ["@nuxthq/ui", "@nuxtjs/color-mode", "nuxt-icon"],
   css: ["~/assets/css/main.css"],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "^18",
         "dotenv": "^16.3.1",
         "nuxt": "^3.6.0",
+        "nuxt-icon": "^0.4.2",
         "prettier": "^2.8.8",
         "prettier-plugin-tailwindcss": "^0.3.0",
         "prisma": "^4.16.2",
@@ -1617,6 +1618,21 @@
         "debug": "^4.3.4",
         "kolorist": "^1.8.0",
         "local-pkg": "^0.4.3"
+      }
+    },
+    "node_modules/@iconify/vue": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@iconify/vue/-/vue-4.1.1.tgz",
+      "integrity": "sha512-RL85Bm/DAe8y6rT6pux7D2FJSiUEM/TPfyK7GrbAOfTSwrhvwJW+S5yijdGcmtXouA8MtuH9C7l4hiSE4mLMjg==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "vue": ">=3"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -10475,6 +10491,64 @@
         }
       }
     },
+    "node_modules/nuxt-icon": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/nuxt-icon/-/nuxt-icon-0.4.2.tgz",
+      "integrity": "sha512-yFpvDA+FuUz+ixtt1eRzctTfR4sl7egZoXu7LL+CUc42qFlzCMaTZJ9eqFR2FTW8zu9tfLIZ83RJmUa1jNEWgg==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/vue": "^4.1.1",
+        "@nuxt/kit": "^3.6.1"
+      }
+    },
+    "node_modules/nuxt-icon/node_modules/@nuxt/kit": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.6.5.tgz",
+      "integrity": "sha512-uBI5I2Zx6sk+vRHU+nBmifwxg/nyXCGZ1g5hUKrUfgv1ZfiKB8JkN5T9iRoduDOaqbwM6XSnEl1ja73iloDcrw==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/schema": "3.6.5",
+        "c12": "^1.4.2",
+        "consola": "^3.2.3",
+        "defu": "^6.1.2",
+        "globby": "^13.2.2",
+        "hash-sum": "^2.0.0",
+        "ignore": "^5.2.4",
+        "jiti": "^1.19.1",
+        "knitwork": "^1.0.0",
+        "mlly": "^1.4.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "scule": "^1.0.0",
+        "semver": "^7.5.3",
+        "unctx": "^2.3.1",
+        "unimport": "^3.0.14",
+        "untyped": "^1.3.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/nuxt-icon/node_modules/@nuxt/schema": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.6.5.tgz",
+      "integrity": "sha512-UPUnMB0W5TZ/Pi1fiF71EqIsPlj8LGZqzhSf8wOeh538KHwxbA9r7cuvEUU92eXRksOZaylbea3fJxZWhOITVw==",
+      "dev": true,
+      "dependencies": {
+        "defu": "^6.1.2",
+        "hookable": "^5.5.3",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "postcss-import-resolver": "^2.0.0",
+        "std-env": "^3.3.3",
+        "ufo": "^1.1.2",
+        "unimport": "^3.0.14",
+        "untyped": "^1.3.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.2.1.tgz",
@@ -16923,6 +16997,15 @@
         "debug": "^4.3.4",
         "kolorist": "^1.8.0",
         "local-pkg": "^0.4.3"
+      }
+    },
+    "@iconify/vue": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@iconify/vue/-/vue-4.1.1.tgz",
+      "integrity": "sha512-RL85Bm/DAe8y6rT6pux7D2FJSiUEM/TPfyK7GrbAOfTSwrhvwJW+S5yijdGcmtXouA8MtuH9C7l4hiSE4mLMjg==",
+      "dev": true,
+      "requires": {
+        "@iconify/types": "^2.0.0"
       }
     },
     "@ioredis/commands": {
@@ -23593,6 +23676,60 @@
         "vue-bundle-renderer": "^1.0.3",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.2.2"
+      }
+    },
+    "nuxt-icon": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/nuxt-icon/-/nuxt-icon-0.4.2.tgz",
+      "integrity": "sha512-yFpvDA+FuUz+ixtt1eRzctTfR4sl7egZoXu7LL+CUc42qFlzCMaTZJ9eqFR2FTW8zu9tfLIZ83RJmUa1jNEWgg==",
+      "dev": true,
+      "requires": {
+        "@iconify/vue": "^4.1.1",
+        "@nuxt/kit": "^3.6.1"
+      },
+      "dependencies": {
+        "@nuxt/kit": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.6.5.tgz",
+          "integrity": "sha512-uBI5I2Zx6sk+vRHU+nBmifwxg/nyXCGZ1g5hUKrUfgv1ZfiKB8JkN5T9iRoduDOaqbwM6XSnEl1ja73iloDcrw==",
+          "dev": true,
+          "requires": {
+            "@nuxt/schema": "3.6.5",
+            "c12": "^1.4.2",
+            "consola": "^3.2.3",
+            "defu": "^6.1.2",
+            "globby": "^13.2.2",
+            "hash-sum": "^2.0.0",
+            "ignore": "^5.2.4",
+            "jiti": "^1.19.1",
+            "knitwork": "^1.0.0",
+            "mlly": "^1.4.0",
+            "pathe": "^1.1.1",
+            "pkg-types": "^1.0.3",
+            "scule": "^1.0.0",
+            "semver": "^7.5.3",
+            "unctx": "^2.3.1",
+            "unimport": "^3.0.14",
+            "untyped": "^1.3.2"
+          }
+        },
+        "@nuxt/schema": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.6.5.tgz",
+          "integrity": "sha512-UPUnMB0W5TZ/Pi1fiF71EqIsPlj8LGZqzhSf8wOeh538KHwxbA9r7cuvEUU92eXRksOZaylbea3fJxZWhOITVw==",
+          "dev": true,
+          "requires": {
+            "defu": "^6.1.2",
+            "hookable": "^5.5.3",
+            "pathe": "^1.1.1",
+            "pkg-types": "^1.0.3",
+            "postcss-import-resolver": "^2.0.0",
+            "std-env": "^3.3.3",
+            "ufo": "^1.1.2",
+            "unimport": "^3.0.14",
+            "untyped": "^1.3.2"
+          }
+        }
       }
     },
     "nypm": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^18",
     "dotenv": "^16.3.1",
     "nuxt": "^3.6.0",
+    "nuxt-icon": "^0.4.2",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",
     "prisma": "^4.16.2",


### PR DESCRIPTION
Resolve #84 

New package dependency added – nuxt-icon, requires npm install.

note: the emojis and their name in the mood tracker section are not buttons. They are there to help the user identify the mood used in the chart. Depending on the type of chart for the mood, these emojis can be removed and included in the chart. 
