### PR TITLE
fix(ui-mood): improve mood chart and selector responsiveness

### DIFF
--- a/components/MoodChart.vue
+++ b/components/MoodChart.vue
@@ -24,6 +24,7 @@ const config = {
   data: data,
   options: {
     responsive: true,
+    maintainAspectRatio: false,
     scales: {
       y: {
         ticks: {
@@ -69,7 +70,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div>
-    <canvas id="myChart" class="w-64"></canvas>
+  <div class="w-11/12">
+    <canvas id="myChart"></canvas>
   </div>
 </template>

--- a/components/MoodSelector.vue
+++ b/components/MoodSelector.vue
@@ -1,29 +1,29 @@
 <template>
   <div class="flex justify-between">
-    <div class="text-center">
+    <div class="flex-col text-center">
       <button class="transition duration-150 hover:scale-150">
         <MoodIconsMotivated class="h-6 w-6" />
       </button>
-      <span class="text-xs text-stone-400">Motivated</span>
+      <div class="text-xs text-stone-400">Motivated</div>
     </div>
 
     <div class="text-center">
       <button class="transition duration-150 hover:scale-150">
         <MoodIconsRelaxed class="h-6 w-6" />
       </button>
-      <span class="text-xs text-stone-400">Relaxed</span>
+      <div class="text-xs text-stone-400">Relaxed</div>
     </div>
     <div class="text-center">
       <button class="transition duration-150 hover:scale-150">
         <MoodIconsStressed class="h-6 w-6" />
       </button>
-      <span class="text-xs text-stone-400">Stressed</span>
+      <div class="text-xs text-stone-400">Stressed</div>
     </div>
     <div class="text-center">
       <button class="transition duration-150 hover:scale-150">
         <MoodIconsDepressed class="h-6 w-6" />
       </button>
-      <span class="text-xs text-stone-400">Depressed</span>
+      <div class="text-xs text-stone-400">Depressed</div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Resolves #99 

Fix responsiveness issue for mood chart and mood selector.

**Mood Chart**
before:
<img width="157" alt="chart-before" src="https://github.com/uol-student-life/student-life/assets/101233307/a6542af6-38d6-4595-b511-49895bb71277">

after:
<img width="151" alt="chart-after" src="https://github.com/uol-student-life/student-life/assets/101233307/57a22cad-4950-42df-9672-a170db778674">

**Mood selector**
before:
<img width="175" alt="mood-before" src="https://github.com/uol-student-life/student-life/assets/101233307/f7acdc2d-111c-41d0-8ee4-978c9eba69c7">

after:
<img width="167" alt="mood-after" src="https://github.com/uol-student-life/student-life/assets/101233307/38dcbf36-d9ae-4e50-8104-dc54422ba142">




