### PR TITLE
fix(ui-moodchart): Fix missing data issue in chart

### DIFF
--- a/components/MoodChart.vue
+++ b/components/MoodChart.vue
@@ -25,6 +25,7 @@ const config = {
   options: {
     responsive: true,
     maintainAspectRatio: false,
+    spanGaps: true,
     scales: {
       y: {
         ticks: {


### PR DESCRIPTION
Resolves #103 

Fix issue where the line is disconnected if there is missing data (user didnt select a mood for example)

<img width="190" alt="nodata" src="https://github.com/uol-student-life/student-life/assets/101233307/a5a21ccb-d739-43c5-bf55-403f21847458">

Before
<img width="224" alt="gap-before" src="https://github.com/uol-student-life/student-life/assets/101233307/8eb2a28f-b38c-4352-b3d0-98ae92a275f9">

After
<img width="213" alt="gap-after" src="https://github.com/uol-student-life/student-life/assets/101233307/4dbd129a-564a-4ae0-856b-4ca1759d101c">


