### PR TITLE
bug: fix timezone, set time to 23:59:59 on createJournalByDay()

### DIFF
--- a/components/Journal/Popover.vue
+++ b/components/Journal/Popover.vue
@@ -35,7 +35,8 @@ const addJournal = async (event: Event) => {
   if (journal) {
     props.selectJournal(journal);
   } else {
-    const journal = await createJournalByDate(date.value);
+    // set the hours at the end of the day to be saved as next day on UTC time in the database
+    const journal = await createJournalByDate(new Date(date.value.setHours(23,59,59)));
     props.selectJournal(journal);
   }
 


### PR DESCRIPTION
Resolves: #112 

@lenabaidakova 
This fix on my end the time-zone issue. I set the time of the date given to the `createJournalByDate() ` for the end of the day therefore the journal saved is always in the ISO time (next day). When extracting the information for display it always converted to local time. 
Before it was saving the journal on the save day created, when displaying the journal it display it on the day before it was created. 
Please let me know if it works on your side and if it doesn't affect something else. I couldn't find any other problems.

Appreciated. 

This shows the process:
![image](https://github.com/uol-student-life/student-life/assets/81662672/a48fbcd4-0bd6-4b26-9ccc-7a43bc07cc5a)

For my understanding the process should be like this.
![image](https://github.com/uol-student-life/student-life/assets/81662672/7399ebed-689c-4765-8691-2eea70f43775)

